### PR TITLE
Nami Wallet with CIP-0030 returns an object

### DIFF
--- a/src/lib/sign.js
+++ b/src/lib/sign.js
@@ -25,6 +25,10 @@ export const sign = async (signer, expires_in = '1d', body = {}) => {
   } else {
     throw new Error('"signer" argument should be a function that returns a signature eg: "msg => web3.eth.personal.sign(msg, <YOUR_ADDRESS>)"')
   }
+  
+  if (typeof(signature) === "object") {
+    signature = signature.signature
+  }
 
   if(typeof signature !== 'string') {
     throw new Error('"signer" argument should be a function that returns a signature string (Promise<string>)')


### PR DESCRIPTION
Using window.cardano.nami.signData returns an object containing a "signature" item with this change, solves the problem if it returns an object and if it returns a string it continues as before.